### PR TITLE
FEAT: Enforce specifying time with the date

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -11,11 +11,11 @@ employee_id = "{simplicate employee id}"
 3. Book hours with `simpl book <project name> <time in hours>` optionally you can provide the following arguments: 
  - `-t` to add one or more  jira tickets (`-t LAB-001 LAB-002`)
  - `-m` for additonal context (`-m "ticket took 2 hours longer than planned"`) 
- - `-d` to specify a date for which to book; by default you book for today (`-d "2019-01-01"`)
+ - `-d` to specify a datetime on which to book; by default you book on current utc time. (`-d "2019-01-01T14:05:05"`)
 
  So a command with all options would look something like:
  
- `simpl book myalias 0.5 -t LAB-001 -m "took longer due to dependency updates" -d "2019-11-11"`
+ `simpl book myalias 0.5 -t LAB-001 -m "took longer due to dependency updates" -d "2019-11-11T09:15:55"`
 
 Run `simpl --help` to see more detailed commands.
 

--- a/src/book.rs
+++ b/src/book.rs
@@ -1,7 +1,7 @@
 use crate::config::{init_config_env, init_simplicate_client};
 use crate::links::Link;
 use chrono::offset::Utc;
-use chrono::NaiveDate;
+use chrono::NaiveDateTime;
 use colored::*;
 use serde::Deserialize;
 use serde_json::{to_string_pretty, Value};
@@ -23,9 +23,9 @@ pub struct BookCommand {
     /// Additional context (e.g. 'took longer due to Amazon issues')
     #[structopt(short = "m")]
     pub context: Option<String>,
-    /// Specify a date for which you want to book (YYYY-MM-DD)
+    /// Specify a date for which you want to book (YYYY-MM-DDTHH-MM:SS)
     #[structopt(short = "d")]
-    pub date: Option<NaiveDate>,
+    pub date: Option<NaiveDateTime>,
 }
 
 #[derive(Deserialize)]
@@ -44,7 +44,7 @@ impl BookCommand {
             employee_id: env::var("SIMPL_EMPLOYEE_ID").expect("No employee ID is set"),
             type_id: link.hourtype,
             start_date: match self.date {
-                Some(dt) => dt.and_hms(0, 0, 0),
+                Some(dt) => dt,
                 None => Utc::now().naive_utc(),
             },
             note: Some(self.format_note()),


### PR DESCRIPTION
Why: I find it very limiting to not be able to specify the time when
booking hours.

Potential problem: it's a breaking change i.e. one must specify a
datetime instead of just a date.

This PR may be considered a feature request.